### PR TITLE
修正try-connect-v2.sh可能无法获取数据

### DIFF
--- a/try-connect-v2.sh
+++ b/try-connect-v2.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 
-online=$(curl -sS "https://gw.buaa.edu.cn/cgi-bin/rad_user_info")
+COOKIEFILE=`mktemp`
+online=$(curl -sS -L -c $COOKIEFILE "https://gw.buaa.edu.cn/cgi-bin/rad_user_info")
+rm $COOKIEFILE
+
 grep "not_online_error" <<< $online > /dev/null
 if [[ "$?" != "0" ]]; then
         echo online: $(cut -d, -f1 <<< $online)


### PR DESCRIPTION
follow redirection and keep cookie when accessing GateWay API

网关地址现在加了302重定向到一个带ad_check的网址，并检验cookie中有无设置的AD_VALUE。如果没有可能导致502。

```raw
> GET /cgi-bin/rad_user_info HTTP/1.1
> User-Agent: curl/7.40.0
> Host: gw.buaa.edu.cn
> Accept: */*
> 
< HTTP/1.1 302 Found
< Location: /cgi-bin/rad_user_info?ad_check=1
< Connection: Close
< Set-Cookie: AD_VALUE=xxxxxxxx; Path=/
< 
> GET /cgi-bin/rad_user_info?ad_check=1 HTTP/1.1
> User-Agent: curl/7.40.0
> Host: gw.buaa.edu.cn
> Accept: */*
> Cookie: AD_VALUE=xxxxxxxx
> 
< HTTP/1.1 200 OK
```